### PR TITLE
add computed properties to exchange Hiragana/Katakana

### DIFF
--- a/BoosterPack/String+Extension.swift
+++ b/BoosterPack/String+Extension.swift
@@ -22,6 +22,38 @@ extension String {
 }
 
 
+// MARK: - Hiragana / Katakana
+
+extension String {
+
+    /// Hiragana -> Katakana
+    var katakana: String {
+        return unicodeScalars.reduce("") { (str, c) in
+            var str = str
+            if c.value >= 0x3041 && c.value <= 0x3096 {
+                str.append(UnicodeScalar(c.value + 96))
+            } else {
+                str.append(c)
+            }
+            return str
+        }
+    }
+
+    /// Katakana -> Hiragana
+    var hiragana: String {
+        return unicodeScalars.reduce("") { (str, c) in
+            var str = str
+            if c.value >= 0x30A1 && c.value <= 0x30F6 {
+                str.append(UnicodeScalar(c.value - 96))
+            } else {
+                str.append(c)
+            }
+            return str
+        }
+    }
+}
+
+
 // MARK: - Regex Syntax
 
 extension String {

--- a/BoosterPackTests/StringExtensionsTests.swift
+++ b/BoosterPackTests/StringExtensionsTests.swift
@@ -52,4 +52,16 @@ class StringExtensionsTests: XCTestCase {
 
         XCTAssert(found == true, "Word boundries are failing to register.")
     }
+
+    func testHiraganaToKatakana() {
+        let word = "こんにちは"
+
+        XCTAssert((word.katakana == "コンニチハ"), "Converting word to Katakana is failing.")
+    }
+
+    func testKatakanaToHiragana() {
+        let word = "コンニチハ"
+
+        XCTAssert((word.hiragana == "こんにちは"), "Converting word to Hiragana is failing.")
+    }
 }


### PR DESCRIPTION
I added computed properties to exchange Hiragana to Katakana (Katakana to Hiragana) in `String+Extension.swift`.